### PR TITLE
Reset IVREXT set in previous IVR

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -111,6 +111,7 @@ function ivr_get_config($engine) {
 				//force strict dial timeout :: no
 				if(!$ivr['strict_dial_timeout']) {
 					$ext->add($c, 's', 'start', new ext_setvar("DIGITS",""));
+					$ext->add($c, 's', '', new ext_setvar("IVREXT",""));
 					$ext->add($c, 's', '', new ext_setvar("NODEFOUND","0"));
 					$ext->add($c, 's', '', new ext_setvar("LOCALEXT","0"));
 					$ext->add($c, 's', '', new ext_setvar("DIREXT","0"));


### PR DESCRIPTION
IVREXT could be set in previous IVR, force it to be reset before entering while and ext_read.
See https://community.freepbx.org/t/ivr-using-digits-from-previous-ivr/57864